### PR TITLE
fix (snap): use version 0.6.3 of lua-resty-openssl

### DIFF
--- a/snap/local/patches/0002-lua-resty-openssl-fix.patch
+++ b/snap/local/patches/0002-lua-resty-openssl-fix.patch
@@ -1,0 +1,11 @@
+--- kong-2.0.4-0.rockspec	2020-09-08 14:52:00.257090462 +0100
++++ kong-2.0.4-0.rockspec	2020-09-10 10:14:17.960907669 +0100
+@@ -35,7 +35,7 @@
+   "lua-resty-cookie == 0.1.0",
+   "lua-resty-mlcache == 2.4.1",
+   "lua-messagepack == 0.5.2",
+-  "lua-resty-openssl == 0.4.4",
++  "lua-resty-openssl == 0.6.3",
+   "lua-resty-counter == 0.2.0",
+   -- external Kong plugins
+   "kong-plugin-azure-functions ~> 0.4",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -312,6 +312,10 @@ parts:
       - luarocks
       - lua5.1
       - libyaml-dev
+    override-pull : |
+      snapcraftctl pull
+      cd $SNAPCRAFT_PART_SRC
+      patch  < "$SNAPCRAFT_PROJECT_DIR/snap/local/patches/0002-lua-resty-openssl-fix.patch"
     override-build: |
       # first copy the default config file provided and install it into $SNAPCRAFT_PART_INSTALL/config
       mkdir -p $SNAPCRAFT_PART_INSTALL/config


### PR DESCRIPTION
Without this patch, Kong's spec for lua-resty-openssl is overriden by lua-resty-acme, causing the latest version (0.6.4-1) to get installed, which causes the service to fail to start.